### PR TITLE
PAL: added ZephyrOS port

### DIFF
--- a/pal/zephyros/README.md
+++ b/pal/zephyros/README.md
@@ -1,0 +1,2 @@
+# General
+This platform abstaction layer (PAL) is meant for porting the OPTIGA Trust M library to the [Zephyr Project](https://github.com/zephyrproject-rtos). The complete port will be available as an external Zephyr module and will be placed in Zephyr's own [optiga-trust](https://github.com/zephyrproject-rtos/optiga-trust) reopository.

--- a/pal/zephyros/pal.c
+++ b/pal/zephyros/pal.c
@@ -1,0 +1,55 @@
+/**
+* \copyright
+* MIT License
+*
+* Copyright (c) 2019 Infineon Technologies AG
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE
+*
+* \endcopyright
+*
+* \author Infineon Technologies AG
+*
+* \file pal.c
+*
+* \brief    This file implements the platform abstraction layer APIs.
+*
+* \ingroup  grPAL
+*
+* @{
+*/
+
+
+#include "optiga/pal/pal.h"
+
+
+pal_status_t pal_init(void)
+{
+    return PAL_STATUS_SUCCESS;
+}
+
+
+pal_status_t pal_deinit(void)
+{
+    return PAL_STATUS_SUCCESS;
+}
+
+/**
+* @}
+*/

--- a/pal/zephyros/pal_gpio.c
+++ b/pal/zephyros/pal_gpio.c
@@ -1,0 +1,116 @@
+/**
+* \copyright
+* MIT License
+*
+* Copyright (c) 2019 Infineon Technologies AG
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE
+*
+* \endcopyright
+*
+* \author Infineon Technologies AG
+*
+* \file pal_gpio.c
+*
+* \brief   This file implements the platform abstraction layer APIs for GPIO.
+*
+* \ingroup  grPAL
+*
+* @{
+*/
+
+/* OPTIGA includes */
+#include "pal_zephyr.h"
+#include "optiga/pal/pal_gpio.h"
+#include "optiga/pal/pal_ifx_i2c_config.h"
+
+/* Zephyr OS includes */
+#include <zephyr.h>
+#include <device.h>
+#include <drivers/gpio.h>
+#include <logging/log.h>
+
+LOG_MODULE_DECLARE(TRUST_M, CONFIG_LOG_DEFAULT_LEVEL);
+
+//lint --e{714,715} suppress "This is implemented for overall completion of API"
+pal_status_t pal_gpio_init(const pal_gpio_t *p_gpio_context)
+{   
+    if (p_gpio_context->p_gpio_hw != NULL)
+    {
+        pal_zephyr_gpio_t *gpio_ctx = (pal_zephyr_gpio_t*)(p_gpio_context->p_gpio_hw);
+        
+        gpio_ctx->p_device = device_get_binding(gpio_ctx->p_port_name);
+
+        if (gpio_pin_configure(gpio_ctx->p_device, gpio_ctx->pin, GPIO_DIR_OUT) == 0)
+        {
+            gpio_ctx->init_flag = 1;
+        }
+        else
+        {
+            LOG_ERR("could not configure GPIO-Pin %d", gpio_ctx->pin);
+
+            return PAL_STATUS_FAILURE;
+        }
+    }
+
+    return PAL_STATUS_SUCCESS;
+}
+
+//lint --e{714,715} suppress "This is implemented for overall completion of API"
+pal_status_t pal_gpio_deinit(const pal_gpio_t *p_gpio_context)
+{
+    /* Not used for Zephyr Port */
+    return PAL_STATUS_SUCCESS;
+}
+
+void pal_gpio_set_high(const pal_gpio_t *p_gpio_context)
+{
+    if ((p_gpio_context != NULL) && (p_gpio_context->p_gpio_hw != NULL))
+    {
+        pal_zephyr_gpio_t *gpio_ctx = (pal_zephyr_gpio_t*)(p_gpio_context->p_gpio_hw);
+        
+        // Make sure not to write to uninitialized gpio pins
+        if (gpio_ctx->init_flag == 0)
+        {
+            pal_gpio_init(p_gpio_context);
+        }
+
+        gpio_pin_write(gpio_ctx->p_device, gpio_ctx->pin, HIGH);
+    }
+}
+
+void pal_gpio_set_low(const pal_gpio_t *p_gpio_context)
+{
+    if ((p_gpio_context != NULL) && (p_gpio_context->p_gpio_hw != NULL))
+    {
+        pal_zephyr_gpio_t *gpio_ctx = (pal_zephyr_gpio_t*)(p_gpio_context->p_gpio_hw);
+
+        // Make sure not to write to uninitialized gpio pins
+        if (gpio_ctx->init_flag == 0)
+        {
+            pal_gpio_init(p_gpio_context);
+        }
+
+        gpio_pin_write(gpio_ctx->p_device, gpio_ctx->pin, LOW);
+    }
+}
+
+/**
+* @}
+*/

--- a/pal/zephyros/pal_i2c.c
+++ b/pal/zephyros/pal_i2c.c
@@ -1,0 +1,338 @@
+/**
+* \copyright
+* MIT License
+*
+* Copyright (c) 2019 Infineon Technologies AG
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE
+*
+* \endcopyright
+*
+* \author Infineon Technologies AG
+*
+* \file pal_i2c.c
+*
+* \brief   This file implements the platform abstraction layer(pal) APIs for I2C.
+*
+* \ingroup  grPAL
+*
+* @{
+*/
+
+/* OPTIGA includes */
+#include "pal_zephyr.h"
+#include "optiga/pal/pal_i2c.h"
+
+/* Zephyr OS includes */
+#include <zephyr.h>
+#include <device.h>
+#include <drivers/i2c.h>
+#include <drivers/gpio.h>
+#include <logging/log.h>
+
+LOG_MODULE_DECLARE(TRUST_M, CONFIG_LOG_DEFAULT_LEVEL);
+
+/* Binary semaphore for lock/unlocking access to i2c bus, replaces pal_i2c_acquire/release */
+K_SEM_DEFINE(i2c_bus_lock, BUS_ENTRY_INIT_VALUE , BUS_ENTRY_MAX_VALUE);
+
+/// @cond hidden
+
+_STATIC_H volatile uint32_t g_entry_count = 0;
+_STATIC_H pal_i2c_t * gp_pal_i2c_current_ctx;
+
+//lint --e{715} suppress "This is implemented for overall completion of API"
+_STATIC_H pal_status_t pal_i2c_acquire(const void * p_i2c_context)
+{
+    if (0 == g_entry_count)
+    {
+        g_entry_count++;
+        if (1 == g_entry_count)
+        {
+            return PAL_STATUS_SUCCESS;
+        }
+    }
+    return PAL_STATUS_FAILURE;
+}
+
+//lint --e{715} suppress "The unused p_i2c_context variable is kept for future enhancements"
+_STATIC_H void pal_i2c_release(const void * p_i2c_context)
+{
+    g_entry_count = 0;
+}
+/// @endcond
+
+void invoke_upper_layer_callback (const pal_i2c_t * p_pal_i2c_ctx, optiga_lib_status_t event)
+{
+    upper_layer_callback_t upper_layer_handler;
+    //lint --e{611} suppress "void* function pointer is type casted to upper_layer_callback_t type"
+    upper_layer_handler = (upper_layer_callback_t)p_pal_i2c_ctx->upper_layer_event_handler;
+
+    upper_layer_handler(p_pal_i2c_ctx->p_upper_layer_ctx, event);
+
+    //Release I2C Bus
+    pal_i2c_release(p_pal_i2c_ctx->p_upper_layer_ctx);
+}
+
+/// @cond hidden
+
+// !!!OPTIGA_LIB_PORTING_REQUIRED
+// The next 5 functions are required only in case you have interrupt based i2c implementation
+void i2c_master_end_of_transmit_callback(void)
+{
+    invoke_upper_layer_callback(gp_pal_i2c_current_ctx, PAL_I2C_EVENT_SUCCESS);
+}
+
+void i2c_master_end_of_receive_callback(void)
+{
+    invoke_upper_layer_callback(gp_pal_i2c_current_ctx, PAL_I2C_EVENT_SUCCESS);
+}
+
+void i2c_master_error_detected_callback(void)
+{
+    invoke_upper_layer_callback(gp_pal_i2c_current_ctx, PAL_I2C_EVENT_ERROR);
+}
+
+void i2c_master_nack_received_callback(void)
+{
+    i2c_master_error_detected_callback();
+}
+
+void i2c_master_arbitration_lost_callback(void)
+{
+    i2c_master_error_detected_callback();
+}
+/// @endcond
+
+pal_status_t pal_i2c_init(const pal_i2c_t * p_i2c_context)
+{
+    pal_zephyr_i2c_t *p_i2c_ctx = (pal_zephyr_i2c_t*)(p_i2c_context->p_i2c_hw_config);
+    p_i2c_ctx->p_i2c_dev = device_get_binding(I2C_PORT_NAME);
+    
+    if (p_i2c_ctx->p_i2c_dev == 0)
+    {
+        LOG_ERR("could not bind I2C-device");
+        return PAL_STATUS_FAILURE;
+    }
+
+    return PAL_STATUS_SUCCESS;
+}
+
+pal_status_t pal_i2c_deinit(const pal_i2c_t * p_i2c_context)
+{
+    return PAL_STATUS_SUCCESS;
+}
+
+pal_status_t pal_i2c_write(pal_i2c_t * p_i2c_context, uint8_t * p_data, uint16_t length)
+{
+    int lock_result;
+    int i2c_write_result;
+    pal_status_t status = PAL_STATUS_FAILURE;
+
+    pal_zephyr_i2c_t *p_i2c_ctx = (pal_zephyr_i2c_t*)(p_i2c_context->p_i2c_hw_config);
+
+	if((p_i2c_context != NULL) && (p_i2c_ctx->p_i2c_dev == NULL))
+	{
+		pal_i2c_init(p_i2c_context);
+	}
+
+    //Acquire the I2C bus before read/write
+    lock_result = k_sem_take(&i2c_bus_lock, K_NO_WAIT);
+
+    if (lock_result == BUS_ENTRY_SUCCESS)
+    {
+        gp_pal_i2c_current_ctx = p_i2c_context;
+
+        //Invoke the low level i2c master driver API to write to the bus
+
+        i2c_write_result = i2c_write(p_i2c_ctx->p_i2c_dev, p_data, (u32_t)length, p_i2c_context->slave_address);
+        //printk("[PAL]: I2C write status %d\n", i2c_write_result);
+        
+        if(i2c_write_result != 0)
+        {
+            //If I2C Master fails to invoke the write operation, invoke upper layer event handler with error.
+            
+            //lint --e{611} suppress "void* function pointer is type casted to upper_layer_callback_t type"
+
+            ((upper_layer_callback_t)(p_i2c_context->upper_layer_event_handler))
+                                                       (p_i2c_context->p_upper_layer_ctx , PAL_I2C_EVENT_ERROR);
+        }
+        else
+        {
+			// !!!OPTIGA_LIB_PORTING_REQUIRED
+			/**
+			* Infineon I2C Protocol is a polling based protocol, if foo_i2c_write will fail it will be reported to the 
+			* upper layers by calling 
+			* (p_i2c_context->upper_layer_event_handler))(p_i2c_context->p_upper_layer_ctx , PAL_I2C_EVENT_ERROR);
+			* If the function foo_i2c_write() will succedd then two options are possible
+			* 1. if foo_i2c_write() is interrupt based, then you need to configure interrupts in the function 
+			*    pal_i2c_init() so that on a succesfull transmit interrupt the callback i2c_master_end_of_transmit_callback(),
+			*    in case of successfull receive i2c_master_end_of_receive_callback() callback 
+			*    in case of not acknowedged, arbitration lost, generic error i2c_master_nack_received_callback() or
+			*    i2c_master_arbitration_lost_callback()
+			* 2. If foo_i2c_write() is a blocking function which will return either ok or failure after transmitting data
+			*    you can handle this case directly here and call 
+			*    invoke_upper_layer_callback(gp_pal_i2c_current_ctx, PAL_I2C_EVENT_SUCCESS);
+			*    
+			*/
+
+            ((upper_layer_callback_t)(p_i2c_context->upper_layer_event_handler))
+                                                       (p_i2c_context->p_upper_layer_ctx , PAL_I2C_EVENT_SUCCESS);
+            status = PAL_STATUS_SUCCESS;
+        }
+
+        //Release I2C Bus
+        k_sem_give(&i2c_bus_lock);
+    }
+    else
+    {
+        //lint --e{611} suppress "void* function pointer is type casted to upper_layer_callback_t type"
+        ((upper_layer_callback_t)(p_i2c_context->upper_layer_event_handler))
+                                                        (p_i2c_context->p_upper_layer_ctx , PAL_I2C_EVENT_BUSY);
+        status = PAL_STATUS_I2C_BUSY;
+    }
+    return status;
+}
+
+pal_status_t pal_i2c_read(pal_i2c_t * p_i2c_context, uint8_t * p_data, uint16_t length)
+{
+    int lock_result;
+    pal_status_t status = PAL_STATUS_FAILURE;
+    
+    pal_zephyr_i2c_t *p_i2c_ctx = (pal_zephyr_i2c_t*)(p_i2c_context->p_i2c_hw_config);
+
+    //Acquire the I2C bus before read/write
+    lock_result = k_sem_take(&i2c_bus_lock, K_NO_WAIT);
+    if (lock_result == BUS_ENTRY_SUCCESS)
+    {
+        gp_pal_i2c_current_ctx = p_i2c_context;
+
+        //Invoke the low level i2c master driver API to read from the bus
+        if (i2c_read(p_i2c_ctx->p_i2c_dev, p_data, (u32_t)length, (u16_t)(p_i2c_context->slave_address)))
+        {
+            //If I2C Master fails to invoke the read operation, invoke upper layer event handler with error.
+
+            //lint --e{611} suppress "void* function pointer is type casted to upper_layer_callback_t type"
+            ((upper_layer_callback_t)(p_i2c_context->upper_layer_event_handler))
+                                                       (p_i2c_context->p_upper_layer_ctx , PAL_I2C_EVENT_ERROR);
+
+        }
+        else
+        {
+			// !!!OPTIGA_LIB_PORTING_REQUIRED
+			/**
+			* Similar to the foo_i2c_write() case you can directly call 
+			* invoke_upper_layer_callback(gp_pal_i2c_current_ctx, PAL_I2C_EVENT_SUCCESS);
+			* if you have blocking (non-interrupt) i2c calls
+			*/
+            ((upper_layer_callback_t)(p_i2c_context->upper_layer_event_handler))
+                                                       (p_i2c_context->p_upper_layer_ctx , PAL_I2C_EVENT_SUCCESS);
+
+            status = PAL_STATUS_SUCCESS;
+        }
+
+        //Release I2C Bus
+        k_sem_give(&i2c_bus_lock);
+    }
+    else
+    {
+        status = PAL_STATUS_I2C_BUSY;
+        //lint --e{611} suppress "void* function pointer is type casted to upper_layer_callback_t type"
+        ((upper_layer_callback_t)(p_i2c_context->upper_layer_event_handler))
+                                                        (p_i2c_context->p_upper_layer_ctx , PAL_I2C_EVENT_BUSY);
+    }
+    return status;
+}
+
+pal_status_t pal_i2c_set_bitrate(const pal_i2c_t * p_i2c_context, uint16_t bitrate)
+{
+    int i2c_config_result=1;
+    int lock_result;
+    pal_status_t status = PAL_STATUS_FAILURE;
+    optiga_lib_status_t event = PAL_I2C_EVENT_ERROR;
+
+    pal_zephyr_i2c_t *p_i2c_ctx = (pal_zephyr_i2c_t*)(p_i2c_context->p_i2c_hw_config);
+
+    //Acquire the I2C bus before setting the bitrate
+    lock_result = k_sem_take(&i2c_bus_lock, K_NO_WAIT);
+    if (lock_result == BUS_ENTRY_SUCCESS)
+    {
+        // If the user provided bitrate is greater than the I2C master hardware maximum supported value,
+        // set the I2C master to its maximum supported value.
+        if (bitrate > PAL_I2C_MASTER_MAX_BITRATE)
+        {
+            bitrate = PAL_I2C_MASTER_MAX_BITRATE;
+        }
+
+        // Logic to convert bitrate to correct I2C_SPEED_VALUES from Zephyr
+        switch (bitrate)
+        {
+        case PAL_I2C_MASTER_DEFAULT_BITRATE:
+            i2c_config_result = i2c_configure(p_i2c_ctx->p_i2c_dev, I2C_SPEED_SET(I2C_SPEED_STANDARD) | I2C_MODE_MASTER);
+            break;
+
+        case PAL_I2C_MASTER_FAST_BITRATE:
+            i2c_config_result = i2c_configure(p_i2c_ctx->p_i2c_dev, I2C_SPEED_SET(I2C_SPEED_FAST) | I2C_MODE_MASTER);
+            break;
+
+        case PAL_I2C_MASTER_MAX_BITRATE:
+            i2c_config_result = i2c_configure(p_i2c_ctx->p_i2c_dev, I2C_SPEED_SET(I2C_SPEED_FAST_PLUS) | I2C_MODE_MASTER);
+            break;
+        
+        default:
+            LOG_ERR("requested I2C-Device bitrate not supported");
+            status = PAL_STATUS_FAILURE;
+            break;
+        }
+
+        if (i2c_config_result == 0)
+        {
+            // I2C speed set correctly
+            status = PAL_STATUS_SUCCESS;
+            event = PAL_I2C_EVENT_SUCCESS;
+        }
+        else
+        {
+            LOG_ERR("could not set I2C-device bitrate");
+            status = PAL_STATUS_FAILURE;
+        }
+
+        //Release I2C Bus
+        k_sem_give(&i2c_bus_lock);
+    }
+    else
+    {
+        status = PAL_STATUS_I2C_BUSY;
+        event = PAL_I2C_EVENT_BUSY;
+    }
+    if (0 != p_i2c_context->upper_layer_event_handler)
+    {
+        //lint --e{611} suppress "void* function pointer is type casted to upper_layer_callback_t type"
+        ((callback_handler_t)(p_i2c_context->upper_layer_event_handler))(p_i2c_context->p_upper_layer_ctx, event);
+    }
+    //Release I2C Bus if it was acquired 
+    if (PAL_STATUS_I2C_BUSY != status)
+    {
+        k_sem_give(&i2c_bus_lock);
+    }
+    return status;
+}
+
+/**
+* @}
+*/

--- a/pal/zephyros/pal_ifx_i2c_config.c
+++ b/pal/zephyros/pal_ifx_i2c_config.c
@@ -50,24 +50,28 @@
 /* Inicialize contexts for device I2C and GPIOs header on board */
 pal_zephyr_i2c_t zephyr_i2c_ctx_0 = {
     NULL,
-    I2C_SCL,
-    I2C_SDA,
+    I2C_SCL_PIN,
+    I2C_SDA_PIN,
     I2C_FREQ_KHZ
 };
 
+#ifdef CONFIG_TRUSTM_GPIO_VDD_SUPPORT
 pal_zephyr_gpio_t vdd_zephyr_gpio_ctx_0 = {
     NULL,
-    VDD_PORT_NAME,
-    VDD_PIN,
+    VDD_GPIO_PORT_NAME,
+    VDD_GPIO_PIN,
     0
 };
+#endif
 
+#ifdef CONFIG_TRUSTM_GPIO_RST_SUPPORT
 pal_zephyr_gpio_t rst_zephyr_gpio_ctx_0 = {
     NULL,
-    RST_PORT_NAME,
-    RST_PIN,
+    RST_GPIO_PORT_NAME,
+    RST_GPIO_PIN,
     0
 };
+#endif
 
 /**
  * \brief PAL I2C configuration for OPTIGA. 
@@ -77,7 +81,7 @@ pal_i2c_t optiga_pal_i2c_context_0 =
     /// Pointer to I2C master platform specific context
     (void*)&zephyr_i2c_ctx_0,
     /// Slave address
-    I2C_OPTIGA_ADDRESS,
+    I2C_OPTIGA_ADDR,
     /// Upper layer context
     NULL,
     /// Callback event handler
@@ -89,11 +93,14 @@ pal_i2c_t optiga_pal_i2c_context_0 =
  */
 pal_gpio_t optiga_vdd_0 =
 {
-	// !!!OPTIGA_LIB_PORTING_REQUIRED
     // Platform specific GPIO context for the pin used to toggle Vdd.
 	// You should have vdd_pin define in your system,
 	// alternativly you can put here raw GPIO number, but without the & sign
+#ifdef CONFIG_TRUSTM_GPIO_VDD_SUPPORT
 	(void*)&vdd_zephyr_gpio_ctx_0
+#else
+    (void*)NULL
+#endif
 };
 
 /**
@@ -101,11 +108,14 @@ pal_gpio_t optiga_vdd_0 =
  */
 pal_gpio_t optiga_reset_0 =
 {
-	// !!!OPTIGA_LIB_PORTING_REQUIRED
     // Platform specific GPIO context for the pin used to toggle Reset.
 	// You should have reset_pin define in your system,
 	// alternativly you can put here raw GPIO number, but without the & sign
+#ifdef CONFIG_TRUSTM_GPIO_RST_SUPPORT
     (void*)&rst_zephyr_gpio_ctx_0
+#else
+    (void*)NULL
+#endif
 };
 
 /**

--- a/pal/zephyros/pal_ifx_i2c_config.c
+++ b/pal/zephyros/pal_ifx_i2c_config.c
@@ -1,0 +1,113 @@
+/**
+* \copyright
+* MIT License
+*
+* Copyright (c) 2019 Infineon Technologies AG
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE
+*
+* \endcopyright
+*
+* \author Infineon Technologies AG
+*
+* \file pal_ifx_i2c_config.c
+*
+* \brief   This file implements platform abstraction layer configurations for ifx i2c protocol.
+*
+* \ingroup  grPAL
+*
+* @{
+*/
+
+/* OPTIGA includes */
+#include "pal_zephyr.h"
+#include "optiga/pal/pal_gpio.h"
+#include "optiga/pal/pal_i2c.h"
+#include "optiga/ifx_i2c/ifx_i2c_config.h"
+
+/* Zephyr OS includes */
+#include <zephyr.h>
+#include <device.h>
+#include <drivers/gpio.h>
+#include <drivers/i2c.h>
+
+/* Inicialize contexts for device I2C and GPIOs header on board */
+pal_zephyr_i2c_t zephyr_i2c_ctx_0 = {
+    NULL,
+    I2C_SCL,
+    I2C_SDA,
+    I2C_FREQ_KHZ
+};
+
+pal_zephyr_gpio_t vdd_zephyr_gpio_ctx_0 = {
+    NULL,
+    VDD_PORT_NAME,
+    VDD_PIN,
+    0
+};
+
+pal_zephyr_gpio_t rst_zephyr_gpio_ctx_0 = {
+    NULL,
+    RST_PORT_NAME,
+    RST_PIN,
+    0
+};
+
+/**
+ * \brief PAL I2C configuration for OPTIGA. 
+ */
+pal_i2c_t optiga_pal_i2c_context_0 =
+{
+    /// Pointer to I2C master platform specific context
+    (void*)&zephyr_i2c_ctx_0,
+    /// Slave address
+    I2C_OPTIGA_ADDRESS,
+    /// Upper layer context
+    NULL,
+    /// Callback event handler
+    NULL
+};
+
+/**
+* \brief PAL vdd pin configuration for OPTIGA. 
+ */
+pal_gpio_t optiga_vdd_0 =
+{
+	// !!!OPTIGA_LIB_PORTING_REQUIRED
+    // Platform specific GPIO context for the pin used to toggle Vdd.
+	// You should have vdd_pin define in your system,
+	// alternativly you can put here raw GPIO number, but without the & sign
+	(void*)&vdd_zephyr_gpio_ctx_0
+};
+
+/**
+ * \brief PAL reset pin configuration for OPTIGA.
+ */
+pal_gpio_t optiga_reset_0 =
+{
+	// !!!OPTIGA_LIB_PORTING_REQUIRED
+    // Platform specific GPIO context for the pin used to toggle Reset.
+	// You should have reset_pin define in your system,
+	// alternativly you can put here raw GPIO number, but without the & sign
+    (void*)&rst_zephyr_gpio_ctx_0
+};
+
+/**
+* @}
+*/

--- a/pal/zephyros/pal_logger.c
+++ b/pal/zephyros/pal_logger.c
@@ -1,0 +1,108 @@
+/**
+* \copyright
+* MIT License
+*
+* Copyright (c) 2019 Infineon Technologies AG
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE
+*
+* \endcopyright
+*
+* \author Infineon Technologies AG
+ *
+ * \file    pal_logger.c
+ *
+ * \brief   This file provides the prototypes declarations for pal logger.
+ *
+ * \ingroup grPAL
+ *
+ * @{
+ */
+
+/* OPTIGA includes */
+#include "optiga/pal/pal_logger.h"
+
+/* Zephyr OS includes */
+#include <logging/log.h>
+
+/* Register logging module */
+LOG_MODULE_REGISTER(TRUST_M, CONFIG_LOG_DEFAULT_LEVEL);
+
+pal_logger_t logger_console = {0};
+
+pal_status_t pal_logger_init(void * p_logger_context)
+{
+    pal_status_t return_status = PAL_STATUS_FAILURE;
+    pal_logger_t * p_log_context = p_logger_context;
+
+
+    return_status = PAL_STATUS_SUCCESS;
+    return return_status;
+}
+
+
+pal_status_t pal_logger_deinit(void * p_logger_context)
+{
+    pal_status_t return_status = PAL_STATUS_FAILURE;
+    pal_logger_t * p_log_context = p_logger_context;
+
+    do
+    {
+		// !!!OPTIGA_LIB_PORTING_REQUIRED
+    }while(FALSE);
+    return return_status;
+}
+
+
+pal_status_t pal_logger_write(void * p_logger_context, const uint8_t * p_log_data, uint32_t log_data_length)
+{
+    int8_t i;
+    int32_t return_status = PAL_STATUS_FAILURE;
+    pal_logger_t * p_log_context = p_logger_context;
+    return ((pal_status_t)return_status);
+
+    char buffer[log_data_length+1];
+
+    for (i=0; i<log_data_length; i++)
+    {
+        buffer[i] = *(p_log_data+i);
+    }
+    buffer[i] = 0;
+    
+    LOG_INF("%s", log_strdup(buffer));
+
+    return_status = PAL_STATUS_SUCCESS;
+    return ((pal_status_t)return_status);
+}
+
+pal_status_t pal_logger_read(void * p_logger_context, uint8_t * p_log_data, uint32_t log_data_length)
+{
+
+    int32_t return_status = PAL_STATUS_FAILURE;
+    pal_logger_t * p_log_context = p_logger_context;
+
+    do
+    {
+		// !!!OPTIGA_LIB_PORTING_REQUIRED
+    } while(0);
+    return ((pal_status_t)return_status);
+}
+/**
+ * @}
+ */

--- a/pal/zephyros/pal_logger.c
+++ b/pal/zephyros/pal_logger.c
@@ -50,6 +50,7 @@ pal_status_t pal_logger_init(void * p_logger_context)
 {
     pal_status_t return_status = PAL_STATUS_FAILURE;
     pal_logger_t * p_log_context = p_logger_context;
+    (void)p_log_context;
 
 
     return_status = PAL_STATUS_SUCCESS;
@@ -61,6 +62,7 @@ pal_status_t pal_logger_deinit(void * p_logger_context)
 {
     pal_status_t return_status = PAL_STATUS_FAILURE;
     pal_logger_t * p_log_context = p_logger_context;
+    (void)p_log_context;
 
     do
     {
@@ -75,6 +77,7 @@ pal_status_t pal_logger_write(void * p_logger_context, const uint8_t * p_log_dat
     int8_t i;
     int32_t return_status = PAL_STATUS_FAILURE;
     pal_logger_t * p_log_context = p_logger_context;
+    (void)p_log_context;
     return ((pal_status_t)return_status);
 
     char buffer[log_data_length+1];
@@ -96,6 +99,7 @@ pal_status_t pal_logger_read(void * p_logger_context, uint8_t * p_log_data, uint
 
     int32_t return_status = PAL_STATUS_FAILURE;
     pal_logger_t * p_log_context = p_logger_context;
+    (void)p_log_context;
 
     do
     {

--- a/pal/zephyros/pal_os_datastore.c
+++ b/pal/zephyros/pal_os_datastore.c
@@ -106,7 +106,6 @@ pal_status_t pal_os_datastore_write(uint16_t datastore_id,
     return return_status;
 }
 
-
 pal_status_t pal_os_datastore_read(uint16_t datastore_id, 
                                    uint8_t * p_buffer, 
                                    uint16_t * p_buffer_length)

--- a/pal/zephyros/pal_os_datastore.c
+++ b/pal/zephyros/pal_os_datastore.c
@@ -1,0 +1,166 @@
+/**
+* \copyright
+* MIT License
+*
+* Copyright (c) 2019 Infineon Technologies AG
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE
+*
+* \endcopyright
+*
+* \author Infineon Technologies AG
+*
+* \file pal_os_datastore.c
+*
+* \brief   This file implements the platform abstraction layer APIs for data store.
+*
+* \ingroup  grPAL
+*
+* @{
+*/
+
+#include "optiga/pal/pal_os_datastore.h"
+
+/// @endcond
+/// Size of data store buffer
+#define DATA_STORE_BUFFERSIZE      (0x42)
+
+/// Maximum shared secret length 
+#define SHARED_SECRET_MAX_LENGTH   (0x40U)
+
+//Internal buffer to store manage context data use for data store
+uint8_t data_store_buffer [DATA_STORE_BUFFERSIZE];
+
+//Internal buffer to store application context data use for data store
+uint8_t data_store_app_context_buffer [APP_CONTEXT_SIZE];
+
+//Internal buffer to store the generated shared secret on Host
+uint8_t optiga_platform_binding_shared_secret [SHARED_SECRET_MAX_LENGTH] = {0x00};
+
+
+pal_status_t pal_os_datastore_write(uint16_t datastore_id,
+                                    const uint8_t * p_buffer,
+                                    uint16_t length)
+{
+    pal_status_t return_status = PAL_STATUS_FAILURE;
+
+    switch(datastore_id)
+    {
+        case OPTIGA_PLATFORM_BINDING_SHARED_SECRET_ID:
+        {
+            // !!!OPTIGA_LIB_PORTING_REQUIRED
+            // This has to be enhanced by user only, in case of updating
+            // the platform binding shared secret during the runtime into NVM.
+            // In current implementation, platform binding shared secret is 
+            // stored in RAM.
+            if (length <= sizeof(optiga_platform_binding_shared_secret))
+            {
+                memcpy(optiga_platform_binding_shared_secret, p_buffer, length);
+                return_status = PAL_STATUS_SUCCESS;
+            }
+            break;
+        }
+        case OPTIGA_COMMS_MANAGE_CONTEXT_ID:
+        {
+            // !!!OPTIGA_LIB_PORTING_REQUIRED
+            // This has to be enhanced by user only, in case of storing 
+            // the manage context information in non-volatile memory 
+            // to reuse for later during hard reset scenarios where the 
+            // RAM gets flushed out.
+            memcpy(data_store_buffer,p_buffer,length);
+            return_status = PAL_STATUS_SUCCESS;
+            break;
+        }
+        case OPTIGA_HIBERNATE_CONTEXT_ID:
+        {
+            // !!!OPTIGA_LIB_PORTING_REQUIRED
+            // This has to be enhanced by user only, in case of storing 
+            // the application context information in non-volatile memory 
+            // to reuse for later during hard reset scenarios where the 
+            // RAM gets flushed out.
+            memcpy(data_store_app_context_buffer,p_buffer,length);
+            return_status = PAL_STATUS_SUCCESS;
+            break;
+        }
+        default:
+        {
+            break;
+        }
+    }
+    return return_status;
+}
+
+
+pal_status_t pal_os_datastore_read(uint16_t datastore_id, 
+                                   uint8_t * p_buffer, 
+                                   uint16_t * p_buffer_length)
+{
+    pal_status_t return_status = PAL_STATUS_FAILURE;
+
+    switch(datastore_id)
+    {
+        case OPTIGA_PLATFORM_BINDING_SHARED_SECRET_ID:
+        {
+            // !!!OPTIGA_LIB_PORTING_REQUIRED
+            // This has to be enhanced by user only,
+            // if the platform binding shared secret is stored in non-volatile 
+            // memory with a specific location and not as a const text segement 
+            // else updating the share secret content is good enough.
+
+            if (*p_buffer_length >= sizeof(optiga_platform_binding_shared_secret))
+            {
+                memcpy(p_buffer,optiga_platform_binding_shared_secret, 
+                       sizeof(optiga_platform_binding_shared_secret));
+                *p_buffer_length = sizeof(optiga_platform_binding_shared_secret);
+                return_status = PAL_STATUS_SUCCESS;
+            }
+            break;
+        }
+        case OPTIGA_COMMS_MANAGE_CONTEXT_ID:
+        {
+            // !!!OPTIGA_LIB_PORTING_REQUIRED
+            // This has to be enhanced by user only,
+            // if manage context information is stored in NVM during the hibernate, 
+            // else this is not required to be enhanced.
+            memcpy(p_buffer,data_store_buffer,*p_buffer_length);
+            return_status = PAL_STATUS_SUCCESS;
+            break;
+        }
+        case OPTIGA_HIBERNATE_CONTEXT_ID:
+        {
+            // !!!OPTIGA_LIB_PORTING_REQUIRED
+            // This has to be enhanced by user only,
+            // if application context information is stored in NVM during the hibernate, 
+            // else this is not required to be enhanced.
+            memcpy(p_buffer,data_store_app_context_buffer,*p_buffer_length);
+            return_status = PAL_STATUS_SUCCESS;
+            break;
+        }
+        default:
+        {
+            break;
+        }
+    }
+
+    return return_status;
+}
+
+/**
+* @}
+*/

--- a/pal/zephyros/pal_os_event.c
+++ b/pal/zephyros/pal_os_event.c
@@ -1,0 +1,148 @@
+/**
+* \copyright
+* MIT License
+*
+* Copyright (c) 2019 Infineon Technologies AG
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE
+*
+* \endcopyright
+*
+* \author Infineon Technologies AG
+*
+* \file pal_os_event.c
+*
+* \brief   This file implements the platform abstraction layer APIs for os event/scheduler.
+*
+* \ingroup  grPAL
+*
+* @{
+*/
+
+/* OPTIGA includes */
+#include "pal_zephyr.h"
+#include "optiga/pal/pal.h"
+#include "optiga/pal/pal_os_event.h"
+
+/* Zephyr OS includes */
+#include <kernel.h>
+#include <logging/log.h>
+
+LOG_MODULE_DECLARE(TRUST_M, CONFIG_LOG_DEFAULT_LEVEL);
+
+// Use this instead of normal pal_os_event_trigger_registered_callback to avoid mismatch of parameters
+static void pal_os_event_trigger_registered_callback_wq(struct k_work *item);
+
+struct pal_info {
+    struct k_delayed_work work;
+    char name[16];
+} pal_device;
+
+/// @cond hidden
+
+static pal_os_event_t pal_os_event_0 = {0};
+
+void pal_os_event_start(pal_os_event_t * p_pal_os_event, register_callback callback, void * callback_args)
+{
+    if (FALSE == p_pal_os_event->is_event_triggered)
+    {
+        p_pal_os_event->is_event_triggered = TRUE;
+        pal_os_event_register_callback_oneshot(p_pal_os_event, callback,callback_args, 1000);
+    }
+}
+
+void pal_os_event_stop(pal_os_event_t * p_pal_os_event)
+{
+    //lint --e{714} suppress "The API pal_os_event_stop is not exposed in header file but used as extern in 
+    //optiga_cmd.c"
+    p_pal_os_event->is_event_triggered = FALSE;
+}
+
+pal_os_event_t * pal_os_event_create(register_callback callback, void * callback_args)
+{
+    if (( NULL != callback )&&( NULL != callback_args ))
+    {
+        pal_os_event_start(&pal_os_event_0, callback, callback_args);
+    }
+    return (&pal_os_event_0);
+}
+
+void pal_os_event_trigger_registered_callback(void)
+{
+    register_callback callback;
+
+    if (pal_os_event_0.callback_registered)
+    {
+        callback = pal_os_event_0.callback_registered;
+        callback((void *)pal_os_event_0.callback_ctx);
+    } 
+}
+/// @endcond
+
+//
+void pal_os_event_trigger_registered_callback_wq(struct k_work *item)
+{
+    register_callback callback;
+
+    if (pal_os_event_0.callback_registered)
+    {
+        callback = pal_os_event_0.callback_registered;
+        callback((void *)pal_os_event_0.callback_ctx);
+    } 
+}
+
+void pal_os_event_register_callback_oneshot(pal_os_event_t * p_pal_os_event,
+                                             register_callback callback,
+                                             void * callback_args,
+                                             uint32_t time_us)
+{
+    /* TODO: put it in a different location
+    * 
+    *
+    */
+    static int flag = 0;
+    if (flag == 0)
+    {
+        strcpy(pal_device.name, "PAL_dev");
+        k_delayed_work_init(&pal_device.work, pal_os_event_trigger_registered_callback_wq);
+        flag++;
+    }
+    
+    p_pal_os_event->callback_registered = callback;
+    p_pal_os_event->callback_ctx = callback_args;
+
+    // Zephyr timeout API uses a resolution of 1 ms.
+    if (time_us < 1000)
+    {
+        time_us = 1000;
+    }
+
+    // Submit work item with specified delay to work queue
+    k_delayed_work_submit(&pal_device.work, K_MSEC(time_us/1000));
+}
+
+//lint --e{818,715} suppress "As there is no implementation, pal_os_event is not used"
+void pal_os_event_destroy(pal_os_event_t * pal_os_event)
+{
+    // User should take care to destroy the event if it's not required
+}
+
+/**
+* @}
+*/

--- a/pal/zephyros/pal_os_lock.c
+++ b/pal/zephyros/pal_os_lock.c
@@ -35,6 +35,7 @@
 * @{
 */
 
+/* OPTIGA includes */
 #include "optiga/pal/pal_os_lock.h"
 
 /* Zephyr OS includes */

--- a/pal/zephyros/pal_os_lock.c
+++ b/pal/zephyros/pal_os_lock.c
@@ -1,0 +1,92 @@
+/**
+* \copyright
+* MIT License
+*
+* Copyright (c) 2019 Infineon Technologies AG
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE
+*
+* \endcopyright
+*
+* \author Infineon Technologies AG
+*
+* \file pal_os_lock.c
+*
+* \brief   This file implements the platform abstraction layer APIs for os locks (e.g. semaphore).
+*
+* \ingroup  grPAL
+*
+* @{
+*/
+
+#include "optiga/pal/pal_os_lock.h"
+
+/* Zephyr OS includes */
+#include <zephyr.h>
+
+#define PAL_OS_LOCK_TAKE_SUCCESS    0
+#define PAL_OS_LOCK_INIT_VALUE      1
+#define PAL_OS_LOCK_MAX_VALUE       1
+
+/* Create binary semaphore at compile time */
+K_SEM_DEFINE(pal_os_lock, PAL_OS_LOCK_INIT_VALUE, PAL_OS_LOCK_MAX_VALUE);
+
+void pal_os_lock_create(pal_os_lock_t * p_lock, uint8_t lock_type)
+{
+    p_lock->type = lock_type;
+    p_lock->lock = 0;
+}
+
+//lint --e{715} suppress "p_lock is not used here as it is placeholder for future." 
+//lint --e{818} suppress "Not declared as pointer as nothing needs to be updated in the pointer."
+void pal_os_lock_destroy(pal_os_lock_t * p_lock)
+{
+    
+}
+
+pal_status_t pal_os_lock_acquire(pal_os_lock_t * p_lock)
+{
+    pal_status_t return_status = PAL_STATUS_FAILURE;
+
+    if (k_sem_take(&pal_os_lock, K_FOREVER) == PAL_OS_LOCK_TAKE_SUCCESS)
+    {
+        return_status = PAL_STATUS_SUCCESS;
+    }
+
+    return return_status;
+}
+
+void pal_os_lock_release(pal_os_lock_t * p_lock)
+{
+    k_sem_give(&pal_os_lock);
+}
+
+void pal_os_lock_enter_critical_section()
+{
+
+}
+
+void pal_os_lock_exit_critical_section()
+{
+    
+}
+
+/**
+* @}
+*/

--- a/pal/zephyros/pal_os_timer.c
+++ b/pal/zephyros/pal_os_timer.c
@@ -1,0 +1,78 @@
+/**
+* \copyright
+* MIT License
+*
+* Copyright (c) 2019 Infineon Technologies AG
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE
+*
+* \endcopyright
+*
+* \author Infineon Technologies AG
+*
+* \file pal_os_timer.c
+*
+* \brief   This file implements the platform abstraction layer APIs for timer.
+*
+* \ingroup  grPAL
+*
+* @{
+*/
+
+#include "optiga/pal/pal_os_timer.h"
+
+/* Zephyr OS includes */
+#include <kernel.h>
+
+/// @cond hidden
+static volatile uint32_t g_tick_count = 0;
+
+/// @endcond
+
+
+uint32_t pal_os_timer_get_time_in_microseconds(void)
+{
+    static uint32_t count = 0;
+    return (count++);
+}
+
+uint32_t pal_os_timer_get_time_in_milliseconds(void)
+{
+    return k_uptime_get_32();
+}
+
+void pal_os_timer_delay_in_milliseconds(uint16_t milliseconds)
+{
+    k_sleep((s32_t)milliseconds);
+}
+
+//lint --e{714} suppress "This is implemented for overall completion of API"
+pal_status_t pal_timer_init(void)
+{
+    return PAL_STATUS_SUCCESS;
+}
+
+//lint --e{714} suppress "This is implemented for overall completion of API"
+pal_status_t pal_timer_deinit(void)
+{
+    return PAL_STATUS_SUCCESS;
+}
+/**
+* @}
+*/

--- a/pal/zephyros/pal_zephyr.h
+++ b/pal/zephyros/pal_zephyr.h
@@ -41,15 +41,32 @@
 /* OPTIGA includes */
 #include "optiga/pal/pal.h"
 
-/* TODO: Make defines not static but depending on KCONFIG */
-#define I2C_OPTIGA_ADDRESS  CONFIG_TRUSTM_I2C_ADDR
+/* OPTIGA Trust M slave address */
+#ifndef CONFIG_TRUSTM_I2C_ADDR
+    #define I2C_OPTIGA_ADDR  0x30
+#else
+    #define I2C_OPTIGA_ADDR  CONFIG_TRUSTM_I2C_ADDR
+#endif
 
+/* I2C PORT to which OPTIGA Trust M is connected */
+#ifndef CONFIG_TRUSTM_I2C_PORT_NAME
+    #define I2C_PORT_NAME   DT_ALIAS_I2C_0_LABEL
+#else
+    #define I2C_PORT_NAME   CONFIG_TRUSTM_I2C_PORT_NAME // DT_ALIAS_I2C_0_LABEL
+#endif
 
-/* I2C PORT to be used to connection */
-#define I2C_PORT_NAME     CONFIG_TRUSTM_I2C_PORT_NAME // DT_ALIAS_I2C_0_LABEL
-/* I2C_0 pins on nRF52840_pca10056 */
-#define I2C_SDA     26 /* 26 */
-#define I2C_SCL     27 /* 27 */
+/* I2C PORT GPIO pins for SDA and SCL */
+#ifndef CONGIG_TRUSTM_I2C_SDA_PIN
+    #define I2C_SDA_PIN DT_ALIAS_I2C_0_SDA_PIN
+#else
+    #define I2C_SDA_PIN CONFIG_TRUSTM_I2C_SDA_PIN /*26*/
+#endif
+
+#ifndef CONGIG_TRUSTM_I2C_SCL_PIN
+    #define I2C_SCL_PIN DT_ALIAS_I2C_0_SCL_PIN 
+#else
+    #define I2C_SCL_PIN CONFIG_TRUSTM_I2C_SCL_PIN /*27*/
+#endif
 
 /*
  * Zephyr OS I2C SPEED TABLE
@@ -60,23 +77,41 @@
  * I2C_SPEED_ULTRA      = 5 :=  5.0 MHz
  * 
  */
-#define I2C_FREQ_KHZ                    (100U)
+#ifdef TRUSTM_I2C_SPEED_FAST
+    #define I2C_FREQ_KHZ    (400U)
+#elif defined(TRUSTM_I2C_SPEED_FAST_PLUS)
+    #define I2C_FREQ_KHZ    (1000U)
+#else
+    #define I2C_FREQ_KHZ    (100U)
+#endif
+
 #define PAL_I2C_MASTER_DEFAULT_BITRATE  (100U)
 #define PAL_I2C_MASTER_FAST_BITRATE     (400U)
 #define PAL_I2C_MASTER_MAX_BITRATE      (1000U)
 
 /* Defines for semaphore mechanism to lock down acccess to i2c bus */
-#define BUS_ENTRY_SUCCESS       0
-#define BUS_ENTRY_INIT_VALUE    1
-#define BUS_ENTRY_MAX_VALUE     1
+#define I2C_BUS_ENTRY_SUCCESS       0
+#define I2C_BUS_ENTRY_INIT_VALUE    1
+#define I2C_BUS_ENTRY_MAX_VALUE     1
 
 /* GPIOs ports & pins used to control VDD and RST lines: e.g. on nRF52840_pca10056 */
-#define VDD_PORT_NAME   CONFIG_TRUSTM_VDD_GPIO_PORT_NAME // DT_GPIO_P1_DEV_NAME // "GPIO_1"
-#define RST_PORT_NAME   CONFIG_TRUSTM_RST_GPIO_PORT_NAME // DT_GPIO_P1_DEV_NAME // "GPIO_1"
-#define VDD_PIN         CONFIG_TRUSTM_VDD_PIN // 7 -> P1.07
-#define RST_PIN         CONFIG_TRUSTM_RST_PIN // 8 -> P1.08
+#ifdef CONFIG_TRUSTM_GPIO_VDD_SUPPORT
+    #define VDD_GPIO_PORT_NAME  CONFIG_TRUSTM_VDD_GPIO_PORT_NAME    // DT_GPIO_P1_DEV_NAME // "GPIO_1"
+    #define VDD_GPIO_PIN        CONFIG_TRUSTM_VDD_GPIO_PIN          // 7 -> P1.07
+#else
+    #define VDD_GPIO_PORT_NAME  NULL
+    #define VDD_GPIO_PIN        0
+#endif
 
-/* Defines used for setting GPIO pins*/
+#ifdef CONFIG_TRUSTM_GPIO_RST_SUPPORT
+    #define RST_GPIO_PORT_NAME  CONFIG_TRUSTM_RST_GPIO_PORT_NAME    // DT_GPIO_P1_DEV_NAME // "GPIO_1"
+    #define RST_GPIO_PIN        CONFIG_TRUSTM_RST_GPIO_PIN          // 8 -> P1.08
+#else
+    #define RST_GPIO_PORT_NAME  NULL
+    #define RST_GPIO_PIN        0
+#endif
+
+/* Defines used to set GPIO pin state*/
 #define LOW     0
 #define HIGH    1
 

--- a/pal/zephyros/pal_zephyr.h
+++ b/pal/zephyros/pal_zephyr.h
@@ -1,0 +1,99 @@
+/**
+* \copyright
+* MIT License
+*
+* Copyright (c) 2019 Infineon Technologies AG
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE
+*
+* \endcopyright
+*
+* \author Infineon Technologies AG
+*
+* \file pal_gpio.c
+*
+* \brief   This file provides the prototype declarations w.r.t Zephyr OS.
+*
+* \ingroup  grPAL
+*
+* @{
+*/
+
+#ifndef _PAL_ZEPHYR_H
+#define _PAL_ZEPHYR_H
+
+/* OPTIGA includes */
+#include "optiga/pal/pal.h"
+
+/* TODO: Make defines not static but depending on KCONFIG */
+#define I2C_OPTIGA_ADDRESS  CONFIG_TRUSTM_I2C_ADDR
+
+
+/* I2C PORT to be used to connection */
+#define I2C_PORT_NAME     CONFIG_TRUSTM_I2C_PORT_NAME // DT_ALIAS_I2C_0_LABEL
+/* I2C_0 pins on nRF52840_pca10056 */
+#define I2C_SDA     26 /* 26 */
+#define I2C_SCL     27 /* 27 */
+
+/*
+ * Zephyr OS I2C SPEED TABLE
+ * I2C_SPEED_STANDARD   = 1 :=  100 KHz -> OPTIGA supported
+ * I2C_SPEED_FAST       = 2 :=  400 KHz -> OPTIGA supported
+ * I2C_SPEED_FAST_PLUS  = 3 :=  1.0 MHz ~> OPTIGA supported
+ * I2C_SPEED_HIGH       = 4 :=  3.4 MHz
+ * I2C_SPEED_ULTRA      = 5 :=  5.0 MHz
+ * 
+ */
+#define I2C_FREQ_KHZ                    (100U)
+#define PAL_I2C_MASTER_DEFAULT_BITRATE  (100U)
+#define PAL_I2C_MASTER_FAST_BITRATE     (400U)
+#define PAL_I2C_MASTER_MAX_BITRATE      (1000U)
+
+/* Defines for semaphore mechanism to lock down acccess to i2c bus */
+#define BUS_ENTRY_SUCCESS       0
+#define BUS_ENTRY_INIT_VALUE    1
+#define BUS_ENTRY_MAX_VALUE     1
+
+/* GPIOs ports & pins used to control VDD and RST lines: e.g. on nRF52840_pca10056 */
+#define VDD_PORT_NAME   CONFIG_TRUSTM_VDD_GPIO_PORT_NAME // DT_GPIO_P1_DEV_NAME // "GPIO_1"
+#define RST_PORT_NAME   CONFIG_TRUSTM_RST_GPIO_PORT_NAME // DT_GPIO_P1_DEV_NAME // "GPIO_1"
+#define VDD_PIN         CONFIG_TRUSTM_VDD_PIN // 7 -> P1.07
+#define RST_PIN         CONFIG_TRUSTM_RST_PIN // 8 -> P1.08
+
+/* Defines used for setting GPIO pins*/
+#define LOW     0
+#define HIGH    1
+
+/* I2C device context */
+typedef struct pal_zephyr_i2c {
+    struct device  *p_i2c_dev;
+    uint8_t         scl_pin;
+    uint8_t         sda_pin;
+    uint32_t        bitrate;
+} pal_zephyr_i2c_t;
+
+/* GPIO device context */
+typedef struct pal_zephyr_gpio {
+    struct device   *p_device;
+    char            *p_port_name;
+    uint8_t          pin;
+    uint8_t          init_flag;
+} pal_zephyr_gpio_t;
+
+#endif


### PR DESCRIPTION
Hi @ayushev,
as you know I am working on porting the OPTIGA Trust M library to the [Zephyr Project](https://github.com/zephyrproject-rtos).

Hence I created a Zephyr PAL, which right now works with Zephyr, Nordic's nRF52840-DK and the OPTIGA Trust M Shield2Go. But the PAL is meant to be a general Zephyr PAL, hence all I2C/GPIO defines will be adoptable via Zephyr's build system in the end. Because of that I simply called the new PAL subfolder **zephyros**.

Communication and demos are working with this implementation of the PAL, therefore I would like you to have a look at it. I would like to get some feedback on the overall implementation and maybe things that can/should be improved. Especially your opinion on the implementation in *pal_os_event.c*.

Thanks
Marc