### PR TITLE
PAL: template: Adding missing notes

### DIFF
--- a/pal/NEW_PAL_TEMPLATE/pal_gpio.c
+++ b/pal/NEW_PAL_TEMPLATE/pal_gpio.c
@@ -40,12 +40,22 @@
 //lint --e{714,715} suppress "This is implemented for overall completion of API"
 pal_status_t pal_gpio_init(const pal_gpio_t * p_gpio_context)
 {
+    if ((p_gpio_context != NULL) && (p_gpio_context->p_gpio_hw != NULL))
+    {
+	// !!!OPTIGA_LIB_PORTING_REQUIRED
+        // Your function to set the pin's mode
+    }
     return PAL_STATUS_SUCCESS;
 }
 
 //lint --e{714,715} suppress "This is implemented for overall completion of API"
 pal_status_t pal_gpio_deinit(const pal_gpio_t * p_gpio_context)
 {
+    if ((p_gpio_context != NULL) && (p_gpio_context->p_gpio_hw != NULL))
+    {
+	// !!!OPTIGA_LIB_PORTING_REQUIRED
+        // Your function to reset the pin's mode to e.g. defaults
+    }
     return PAL_STATUS_SUCCESS;
 }
 
@@ -53,8 +63,8 @@ void pal_gpio_set_high(const pal_gpio_t * p_gpio_context)
 {
     if ((p_gpio_context != NULL) && (p_gpio_context->p_gpio_hw != NULL))
     {
-		// !!!OPTIGA_LIB_PORTING_REQUIRED
-        // You function to set the pin high
+	// !!!OPTIGA_LIB_PORTING_REQUIRED
+        // Your function to set the pin high
     }
 }
 
@@ -62,8 +72,8 @@ void pal_gpio_set_low(const pal_gpio_t * p_gpio_context)
 {
     if ((p_gpio_context != NULL) && (p_gpio_context->p_gpio_hw != NULL))
     {
-		// !!!OPTIGA_LIB_PORTING_REQUIRED
-        // You function to set the pin low
+	// !!!OPTIGA_LIB_PORTING_REQUIRED
+        // Your function to set the pin low
     }
 }
 


### PR DESCRIPTION
Adding missing notes about setting and resetting the pin's mode.
While looking at the Linux PAL code, I noticed that if-clauses are possible there, too.
However, I'm not sure whether they are fine like this or not.
If it is helpful for you and your clients, feel free to merge the code or modify it in any way you want.