### PR TITLE
Fix Linux segmentation fault and secure communication issue  

### DIFF
--- a/optiga/include/optiga/optiga_lib_config_m_v3.h
+++ b/optiga/include/optiga/optiga_lib_config_m_v3.h
@@ -110,7 +110,7 @@ extern "C" {
      *         Warm Reset - (2) : This is applicable if the host platform doesn't have GPIO option for VDD. \n
      *         Any other value will lead to error
      */
-    #define OPTIGA_COMMS_DEFAULT_RESET_TYPE     (1U)
+    #define OPTIGA_COMMS_DEFAULT_RESET_TYPE     (0U)
     
     /** @brief NULL parameter check.
      *         To disable the check, undefine the macro

--- a/optiga/include/optiga/optiga_lib_config_m_v3.h
+++ b/optiga/include/optiga/optiga_lib_config_m_v3.h
@@ -110,7 +110,7 @@ extern "C" {
      *         Warm Reset - (2) : This is applicable if the host platform doesn't have GPIO option for VDD. \n
      *         Any other value will lead to error
      */
-    #define OPTIGA_COMMS_DEFAULT_RESET_TYPE     (0U)
+    #define OPTIGA_COMMS_DEFAULT_RESET_TYPE     (1U)
     
     /** @brief NULL parameter check.
      *         To disable the check, undefine the macro

--- a/pal/linux/pal_os_datastore.c
+++ b/pal/linux/pal_os_datastore.c
@@ -2,7 +2,7 @@
 * \copyright
 * MIT License
 *
-* Copyright (c) 2019 Infineon Technologies AG
+* Copyright (c) 2020 Infineon Technologies AG
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
@@ -31,38 +31,44 @@
 * \brief   This file implements the platform abstraction layer APIs for data store.
 *
 * \ingroup  grPAL
+*
 * @{
 */
 
 #include "optiga/pal/pal_os_datastore.h"
+/// @cond hidden
 
-/// @endcond
+/// Size of length field 
+#define LENGTH_SIZE                (0x02)
+/// Size of data store buffer to hold the shielded connection manage context information (2 bytes length field + 64(0x40) bytes context)
+#define MANAGE_CONTEXT_BUFFER_SIZE      (0x42)
 
-/// Size of data store buffer
-#define DATA_STORE_BUFFERSIZE   (0x42)
+//Internal buffer to store the shielded connection manage context information (length field + Data)
+uint8_t data_store_manage_context_buffer [LENGTH_SIZE + MANAGE_CONTEXT_BUFFER_SIZE];
 
-uint8_t data_store_buffer [DATA_STORE_BUFFERSIZE];
+//Internal buffer to store the optiga application context data during hibernate(length field + Data)
+uint8_t data_store_app_context_buffer [LENGTH_SIZE + APP_CONTEXT_SIZE];
 
-//Internal buffer to store application context data use for data store
-uint8_t data_store_app_context_buffer [APP_CONTEXT_SIZE];
-
-const uint8_t optiga_platform_binding_shared_secret [] = {
-    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 
-    0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10,
-    0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 
-    0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F, 0x20,
-    0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 
-    0x29, 0x2A, 0x2B, 0x2C, 0x2D, 0x2E, 0x2F, 0x30,
-    0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 
-    0x39, 0x3A, 0x3B, 0x3C, 0x3D, 0x3E, 0x3F, 0x40
+//Internal buffer to store the generated platform binding shared secret on Host (length field + shared secret)
+uint8_t optiga_platform_binding_shared_secret [LENGTH_SIZE + OPTIGA_SHARED_SECRET_MAX_LENGTH] = 
+{
+    // Length of the shared secret, followed after the length information
+    0x00 ,0x40, 
+    // Shared secret. Buffer is defined to the maximum supported length [64 bytes]. 
+    // But the actual size used is to be specified in the length field.
+    0x01 ,0x02 ,0x03 ,0x04 ,0x05 ,0x06 ,0x07 ,0x08 ,0x09 ,0x0A ,0x0B ,0x0C ,0x0D ,0x0E ,0x0F ,0x10,
+    0x11 ,0x12 ,0x13 ,0x14 ,0x15 ,0x16 ,0x17 ,0x18 ,0x19 ,0x1A ,0x1B ,0x1C ,0x1D ,0x1E ,0x1F ,0x20,
+    0x21 ,0x22 ,0x23 ,0x24 ,0x25 ,0x26 ,0x27 ,0x28 ,0x29 ,0x2A ,0x2B ,0x2C ,0x2D ,0x2E ,0x2F ,0x30,
+    0x31 ,0x32 ,0x33 ,0x34 ,0x35 ,0x36 ,0x37 ,0x38 ,0x39 ,0x3A ,0x3B ,0x3C ,0x3D ,0x3E ,0x3F ,0x40
 };
 
-/// To write the data in the datastore
+
 pal_status_t pal_os_datastore_write(uint16_t datastore_id,
                                     const uint8_t * p_buffer,
                                     uint16_t length)
 {
     pal_status_t return_status = PAL_STATUS_FAILURE;
+    uint8_t offset = 0;
 
     switch(datastore_id)
     {
@@ -70,9 +76,16 @@ pal_status_t pal_os_datastore_write(uint16_t datastore_id,
         {
             // !!!OPTIGA_LIB_PORTING_REQUIRED
             // This has to be enhanced by user only, in case of updating
-            // the platform binding shared secret during the runtime.
-
-            return_status = PAL_STATUS_SUCCESS;
+            // the platform binding shared secret during the runtime into NVM.
+            // In current implementation, platform binding shared secret is 
+            // stored in RAM.
+            if (length <= OPTIGA_SHARED_SECRET_MAX_LENGTH)
+            {
+                optiga_platform_binding_shared_secret[offset++] = (uint8_t)(length>>8);
+                optiga_platform_binding_shared_secret[offset++] = (uint8_t)(length);
+                memcpy(&optiga_platform_binding_shared_secret[offset], p_buffer, length);
+                return_status = PAL_STATUS_SUCCESS;
+            }
             break;
         }
         case OPTIGA_COMMS_MANAGE_CONTEXT_ID:
@@ -82,7 +95,9 @@ pal_status_t pal_os_datastore_write(uint16_t datastore_id,
             // the manage context information in non-volatile memory 
             // to reuse for later during hard reset scenarios where the 
             // RAM gets flushed out.
-            memcpy(data_store_buffer,p_buffer,length);
+            data_store_manage_context_buffer[offset++] = (uint8_t)(length>>8);
+            data_store_manage_context_buffer[offset++] = (uint8_t)(length);
+            memcpy(&data_store_manage_context_buffer[offset],p_buffer,length);
             return_status = PAL_STATUS_SUCCESS;
             break;
         }
@@ -93,7 +108,9 @@ pal_status_t pal_os_datastore_write(uint16_t datastore_id,
             // the application context information in non-volatile memory 
             // to reuse for later during hard reset scenarios where the 
             // RAM gets flushed out.
-            memcpy(data_store_app_context_buffer,p_buffer,length);
+            data_store_app_context_buffer[offset++] = (uint8_t)(length>>8);
+            data_store_app_context_buffer[offset++] = (uint8_t)(length);
+            memcpy(&data_store_app_context_buffer[offset],p_buffer,length);
             return_status = PAL_STATUS_SUCCESS;
             break;
         }
@@ -102,16 +119,17 @@ pal_status_t pal_os_datastore_write(uint16_t datastore_id,
             break;
         }
     }
-
     return return_status;
 }
 
-/// Function to read the data from data store
+
 pal_status_t pal_os_datastore_read(uint16_t datastore_id, 
                                    uint8_t * p_buffer, 
                                    uint16_t * p_buffer_length)
 {
     pal_status_t return_status = PAL_STATUS_FAILURE;
+    uint16_t data_length;
+    uint8_t offset = 0;
 
     switch(datastore_id)
     {
@@ -120,14 +138,15 @@ pal_status_t pal_os_datastore_read(uint16_t datastore_id,
             // !!!OPTIGA_LIB_PORTING_REQUIRED
             // This has to be enhanced by user only,
             // if the platform binding shared secret is stored in non-volatile 
-            // memory with a specific location and not as a const text segement 
+            // memory with a specific location and not as a context segment 
             // else updating the share secret content is good enough.
 
-            if (*p_buffer_length >= sizeof(optiga_platform_binding_shared_secret))
+            data_length = (uint16_t) (optiga_platform_binding_shared_secret[offset++] << 8);
+            data_length |= (uint16_t)(optiga_platform_binding_shared_secret[offset++]);
+            if (data_length <= OPTIGA_SHARED_SECRET_MAX_LENGTH)
             {
-                memcpy(p_buffer,optiga_platform_binding_shared_secret, 
-                       sizeof(optiga_platform_binding_shared_secret));
-                *p_buffer_length = sizeof(optiga_platform_binding_shared_secret);
+                memcpy(p_buffer,&optiga_platform_binding_shared_secret[offset], data_length);
+                *p_buffer_length = data_length;
                 return_status = PAL_STATUS_SUCCESS;
             }
             break;
@@ -138,7 +157,10 @@ pal_status_t pal_os_datastore_read(uint16_t datastore_id,
             // This has to be enhanced by user only,
             // if manage context information is stored in NVM during the hibernate, 
             // else this is not required to be enhanced.
-            memcpy(p_buffer,data_store_buffer,*p_buffer_length);
+            data_length = (uint16_t) (data_store_manage_context_buffer[offset++] << 8);
+            data_length |= (uint16_t)(data_store_manage_context_buffer[offset++]);
+            memcpy(p_buffer, &data_store_manage_context_buffer[offset], data_length);
+            *p_buffer_length = data_length;
             return_status = PAL_STATUS_SUCCESS;
             break;
         }
@@ -148,15 +170,23 @@ pal_status_t pal_os_datastore_read(uint16_t datastore_id,
             // This has to be enhanced by user only,
             // if application context information is stored in NVM during the hibernate, 
             // else this is not required to be enhanced.
-            memcpy(p_buffer,data_store_app_context_buffer,*p_buffer_length);
+            data_length = (uint16_t) (data_store_app_context_buffer[offset++] << 8);
+            data_length |= (uint16_t)(data_store_app_context_buffer[offset++]);
+            memcpy(p_buffer, &data_store_app_context_buffer[offset], data_length);
+            *p_buffer_length = data_length;
             return_status = PAL_STATUS_SUCCESS;
             break;
         }
         default:
         {
+            *p_buffer_length = 0;
             break;
         }
     }
 
     return return_status;
 }
+/// @endcond
+/**
+* @}
+*/

--- a/pal/linux/pal_os_event.c
+++ b/pal/linux/pal_os_event.c
@@ -2,7 +2,7 @@
 * \copyright
 * MIT License
 *
-* Copyright (c) 2019 Infineon Technologies AG
+* Copyright (c) 2020 Infineon Technologies AG
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
@@ -39,7 +39,6 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <signal.h>
-#include <errno.h>
 #include <time.h>
 #include "optiga/pal/pal_os_timer.h"
 #include "optiga/pal/pal_os_event.h"
@@ -68,48 +67,97 @@
 
 static void handler(int sig, siginfo_t *si, void *uc)
 {
-    TRUSTM_PAL_EVENT_DBGFN(">"); 
-    pal_os_event_trigger_registered_callback();
-    TRUSTM_PAL_EVENT_DBGFN("<");   
+	TRUSTM_PAL_EVENT_DBGFN(">");    
+	pal_os_event_trigger_registered_callback();
+	TRUSTM_PAL_EVENT_DBGFN("<");    
 }
 
 
 /// @cond hidden
 
 static pal_os_event_t pal_os_event_0 = {0};
-static     timer_t timerid;
+static 	timer_t timerid;
 
 void pal_os_event_start(pal_os_event_t * p_pal_os_event, register_callback callback, void * callback_args)
 {
-    TRUSTM_PAL_EVENT_DBGFN(">");
-
+    TRUSTM_PAL_EVENT_DBGFN(">");    
+    
     if(FALSE == p_pal_os_event->is_event_triggered)
     {
         p_pal_os_event->is_event_triggered = TRUE;
         pal_os_event_register_callback_oneshot(p_pal_os_event,callback,callback_args,1000);
     }
+    TRUSTM_PAL_EVENT_DBGFN("<");    
 
-    TRUSTM_PAL_EVENT_DBGFN("<"); 
 }
 
 void pal_os_event_stop(pal_os_event_t * p_pal_os_event)
 {
-    TRUSTM_PAL_EVENT_DBGFN(">");
+    TRUSTM_PAL_EVENT_DBGFN(">");    
+    
     //lint --e{714} suppress "The API pal_os_event_stop is not exposed in header file but used as extern in optiga_cmd.c"
     p_pal_os_event->is_event_triggered = FALSE;
-    TRUSTM_PAL_EVENT_DBGFN("<"); 
+
+    TRUSTM_PAL_EVENT_DBGFN("<");    
+
+}
+
+void pal_os_event_disarm(void)
+{
+	struct itimerspec its;
+
+	TRUSTM_PAL_EVENT_DBGFN(">");    
+	its.it_value.tv_sec = 0;
+	its.it_value.tv_nsec = 0;
+	its.it_interval.tv_sec = 0;
+	its.it_interval.tv_nsec = 0;
+	
+	if (timer_settime(timerid, 0, &its, NULL) == -1)
+	{
+		printf("Error in timer_settime\n");
+	    exit(1);
+	}
+
+	TRUSTM_PAL_EVENT_DBGFN("<");    
+} 
+
+void pal_os_event_arm(void)
+{   
+	struct itimerspec its;
+
+	TRUSTM_PAL_EVENT_DBGFN(">");    
+	its.it_value.tv_sec = 0;
+	its.it_value.tv_nsec = 1000000;
+	its.it_interval.tv_sec = 0;
+	its.it_interval.tv_nsec = 294967296;
+	
+	if (timer_settime(timerid, 0, &its, NULL) == -1)
+	{
+		printf("Error in timer_settime\n");
+	    exit(1);
+	}
+
+	TRUSTM_PAL_EVENT_DBGFN("<");    
+} 
+
+void pal_os_event_destroy1(void)
+{
+    TRUSTM_PAL_EVENT_DBGFN(">");    
+    timer_delete(timerid);
+    TRUSTM_PAL_EVENT_DBGFN("<");    
 }
 
 pal_os_event_t * pal_os_event_create(register_callback callback, void * callback_args)
 {
     struct sigevent sev;
     struct sigaction sa;
-    
-    TRUSTM_PAL_EVENT_DBGFN(">");
-    
+
+    TRUSTM_PAL_EVENT_DBGFN(">");    
+	
     if(( NULL != callback )&&( NULL != callback_args ))
     {
-        /* Establishing handler for signal */
+		/* Establishing handler for signal */
+		
         sa.sa_flags = SA_SIGINFO;
         sa.sa_sigaction = handler;
         sigemptyset(&sa.sa_mask);
@@ -126,14 +174,14 @@ pal_os_event_t * pal_os_event_create(register_callback callback, void * callback
         sev.sigev_value.sival_ptr = &timerid;
         if (timer_create(CLOCKID, &sev, &timerid) == -1)
         {
-            printf("error in timer_create\n");
+            printf("timer_create\n");
             exit(1);
         }
 
         pal_os_event_start(&pal_os_event_0,callback,callback_args);
     }
-    
-    TRUSTM_PAL_EVENT_DBGFN("<");
+
+    TRUSTM_PAL_EVENT_DBGFN("<");    
     
     return (&pal_os_event_0);
 }
@@ -143,27 +191,33 @@ void pal_os_event_trigger_registered_callback(void)
     register_callback callback;
     struct itimerspec its;
 
-    TRUSTM_PAL_EVENT_DBGFN(">");  
-    
-    its.it_value.tv_sec = 0;
-    its.it_value.tv_nsec = 0;
-    its.it_interval.tv_sec = 0;
-    its.it_interval.tv_nsec = 0;
-    
-    if (timer_settime(timerid, 0, &its, NULL) == -1)
-    {
-        fprintf(stderr, "Error in timer_settime\n");
-        exit(1);
-    }
+    // !!!OPTIGA_LIB_PORTING_REQUIRED
+    // The following steps related to TIMER must be taken care while porting to different platform
+    // TBD
+    TRUSTM_PAL_EVENT_DBGFN(">");    
 
     if (pal_os_event_0.callback_registered)
     {
         callback = pal_os_event_0.callback_registered;
         pal_os_event_0.callback_registered = NULL;
+	
+	// Stop the timer
+	its.it_value.tv_sec = 0;
+	its.it_value.tv_nsec = 0;
+	its.it_interval.tv_sec = 0;
+	its.it_interval.tv_nsec = 0;
+
+	if (timer_settime(timerid, 0, &its, NULL) == -1)
+	{
+	    TRUSTM_PAL_EVENT_ERRFN("Fail to stop the timer\n");
+	    exit(1);
+	}
+	
         callback((void * )pal_os_event_0.callback_ctx);
     }
-
-    TRUSTM_PAL_EVENT_DBGFN("<"); 
+    
+    TRUSTM_PAL_EVENT_DBGFN("<");    
+    
 }
 /// @endcond
 
@@ -172,52 +226,47 @@ void pal_os_event_register_callback_oneshot(pal_os_event_t * p_pal_os_event,
                                              void * callback_args,
                                              uint32_t time_us)
 {
-    struct itimerspec its;
-    long long freq_nanosecs;
-    int ret = 0;
-    //sigset_t mask;
+	struct itimerspec its;
+	long long freq_nanosecs;
+	//sigset_t mask;
 
-    TRUSTM_PAL_EVENT_DBGFN(">");
-    
-    //uint8_t scheduler_timer;
+	TRUSTM_PAL_EVENT_DBGFN(">");    
+
+
+	//uint8_t scheduler_timer;
     p_pal_os_event->callback_registered = callback;
     p_pal_os_event->callback_ctx = callback_args;
-    
-    /* Start the timer */
-    freq_nanosecs = time_us * 1000;
-    its.it_value.tv_sec = (freq_nanosecs / 1000000000);
-    its.it_value.tv_nsec = (freq_nanosecs % 1000000000);
-    its.it_interval.tv_sec = 0;
-    its.it_interval.tv_nsec = 0;
-    
-    if (( ret = timer_settime(timerid, 0, &its, NULL)) == -1)    
-    {
-        int errsv = errno;
-        fprintf(stderr,"timer_settime FAILED!!!\n");
-        if(errsv == EINVAL)
-        {
-            fprintf(stderr,"INVALID VALUE!\n");
-        }
-        else
-        {
-            fprintf(stderr,"UNKOWN ERROR: %d\n",errsv);
-        }
-        exit(1);
-    }
-    
-    TRUSTM_PAL_EVENT_DBGFN("<"); 
+	
+	/* Start the timer */
+
+	freq_nanosecs = time_us * 1000;
+	its.it_value.tv_sec = freq_nanosecs / 1000000000;
+	its.it_value.tv_nsec = freq_nanosecs % 1000000000;
+	its.it_interval.tv_sec = its.it_value.tv_sec;
+	its.it_interval.tv_nsec = its.it_value.tv_nsec;
+
+	//printf("freq_nanosecs = %lld\n", time_us * 1000);
+	//printf("its.it_value.tv_sec = %lld", freq_nanosecs / 1000000000);
+	//printf("its.it_value.tv_nsec = %lld\n", freq_nanosecs % 1000000000);
+	//printf("its.it_interval.tv_sec = %lld\n", its.it_value.tv_sec);
+	//printf("its.it_interval.tv_nsec = %lld\n", its.it_value.tv_nsec);
+
+	
+	if (timer_settime(timerid, 0, &its, NULL) == -1)
+	{
+		printf("timer_settime\n");
+	    exit(1);
+	}
+	TRUSTM_PAL_EVENT_DBGFN("<");    
 }
 
 //lint --e{818,715} suppress "As there is no implementation, pal_os_event is not used"
 void pal_os_event_destroy(pal_os_event_t * pal_os_event)
 {
-    TRUSTM_PAL_EVENT_DBGFN(">"); 
-    pal_os_event_stop(pal_os_event);
-    if (timerid != 0)
-    {
-        timer_delete(timerid);
-    }
-    TRUSTM_PAL_EVENT_DBGFN("<"); 
+    TRUSTM_PAL_EVENT_DBGFN(">");    
+    timer_delete(timerid);
+    TRUSTM_PAL_EVENT_DBGFN("<");    
+
 }
 
 /**


### PR DESCRIPTION

1)Modify pal_os_datastore.c to resolve secure shield communication issue for new trustm library
2)Modify pal_os_event.c to resolve runtime segmentation fault of openssl engine usage by adding ARM and DISARM functions
3)Set default reset to Soft Reset, do not use external HW reset pin